### PR TITLE
Update linear_assignment.py

### DIFF
--- a/deep_sort/linear_assignment.py
+++ b/deep_sort/linear_assignment.py
@@ -1,7 +1,7 @@
 # vim: expandtab:ts=4:sw=4
 from __future__ import absolute_import
 import numpy as np
-from sklearn.utils.linear_assignment_ import linear_assignment
+from scipy.optimize import linear_sum_assignment as linear_assignment
 from . import kalman_filter
 
 


### PR DESCRIPTION
"This pull request updates the import statement for the linear assignment function. The change is necessary because the previously used `linear_assignment` function from `sklearn.utils.linear_assignment_` has been deprecated and removed in recent versions of scikit-learn.

The updated import statement:
```python
from scipy.optimize import linear_sum_assignment as linear_assignment
```

replaces the old import:
```python
from sklearn.utils.linear_assignment_ import linear_assignment
```

This change offers several benefits:
1. It resolves the ModuleNotFoundError that occurs with newer versions of scikit-learn.
2. It uses the `linear_sum_assignment` function from SciPy, which is the recommended replacement for sklearn's deprecated `linear_assignment`.
3. By using `as linear_assignment`, we maintain compatibility with the existing codebase, minimizing necessary changes.